### PR TITLE
README formatting and syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-#SVG
+# SVG
 Allows you to manipulate inline SVGs, including injecting classes, width and height properties, and a11y configuration.
 
-##Version 2
+## Version 2
 This is version two of the plugin. I've pretty much refactored the entire addon and changed some bits that I wasn't happy with.
 
 Breaking changes are listed below:
@@ -11,20 +11,20 @@ This parameter is now `class`, rather than `classes`. Other than that, it remain
 
 Also, due to some changes, it is no longer necessary to run `php please addons:update` before you can use it. It will still say it isn't installed, but you can ignore that!
 
-##Usage
+## Usage
 This tag will output an inline SVG. But that's what the output modifier is for I hear you cry. Believe me. This addon will make your life so much easier that you'll want to cry and name your first born after me... okay, that's maybe too far, but it will make your life a hell of a lot easier.
 
 The only parameter that is necessary with this tag is src (otherwise, what will it output).
 
 You can define this as a path to your asset container, or you can refer to a fieldset key.
 
-``` .language-yaml
+```Handlebars
 {{ svg src="/assets/svg/phone.svg" }}
 ```
 
 or 
 
-``` .language-yaml
+```Handlebars
 ---
 icon: /assets/svg/phone.svg
 ---
@@ -34,17 +34,17 @@ icon: /assets/svg/phone.svg
 
 will work. As I said before, the only crucial thing at the moment is that you need to store your SVGs in an assets container.
 
-##Additional parameters
+## Additional parameters
 Okay, so that's cool, but that's nothing `{{ icon | output }}` couldn't do. The real power of the addon is that you can pass through additional parameters and have them output in the SVG.
 
-###Classes
+### Classes
 You can pass classes into your SVG by using the `class` parameter. This is especially useful if you use TailwindCSS and want to avoid having to create non-class-based CSS.
 
 Let's say you have a solid icon you want to change the colour of. Maybe it's pulled through from the font awesome library and so you can't edit the code, otherwise it'll get wiped out next time you update it. (Want to hazard a guess as to why I built this addon?).
 
 All you'd need to do if you wanted to make that SVG teal is pass through the following classes:
 
-``` .language-yaml
+```Handlebars
 ---
 icon: /assets/svg/phone.svg
 ---
@@ -54,10 +54,10 @@ icon: /assets/svg/phone.svg
 
 You can also pass through height, width and whatever other classes you want to, including its focus, hover, media and active states.
 
-###Width and Height
+### Width and Height
 Want to set the width and the height of an SVG without editing the code of the SVG itself? Easy...
 
-``` .language-yaml
+```Handlebars
 ---
 icon: /assets/svg/phone.svg
 ---
@@ -65,10 +65,10 @@ icon: /assets/svg/phone.svg
 {{ svg src="{ icon }" width="40" height="40" }}
 ```
 
-###A11Y
+### A11Y
 Want to add a title to an SVG to enable those using screen readers to be able to understand what an SVG is all about? Simply pass through something like below and it'll add a title to the SVG.
 
-``` .language-yaml
+```Handlebars
 ---
 icon: /assets/svg/phone.svg
 ---
@@ -78,7 +78,7 @@ icon: /assets/svg/phone.svg
 
 Of course, you can also pass through any page data you want to as well, meaning anyone using the CP can also add accessiblity text. For example, if they add a title to an asset, you can pull it through using the [assets tag](https://docs.statamic.com/tags/assets#single-assets) like so:
 
-``` .language-yaml
+```Handlebars
 ---
 icon: /assets/svg/phone.svg
 ---


### PR DESCRIPTION
This just fixes the spacing between titles and markdown syntax, and adds syntax highlighting for code blocks.