### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ will work. As I said before, the only crucial thing at the moment is that you ne
 ## Additional parameters
 Okay, so that's cool, but that's nothing `{{ icon | output }}` couldn't do. The real power of the addon is that you can pass through additional parameters and have them output in the SVG.
 
+Allow to have IDs in you SVG code by adding paramenter `{{ icon allowIds='true' }}`.
+
 ### Injecting CSS Classes
 You can pass classes into your SVG by using the `class` parameter. This is especially useful if you use TailwindCSS and want to avoid having to create non-class-based CSS.
 


### PR DESCRIPTION
Added Information about allowing of ID's in SVG-Ouput code -> If not `true` it'll clean out all ID's used in the SVG -> That sometimes gives rendering errors if there are `<defs>` used with referenced ID's in the SVG-code.